### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,7 +14,7 @@
       "source" : "git@github.com:jonathanstowe/Lumberjack-Dispatcher-Syslog.git"
    },
    "source-url" : "git@github.com:jonathanstowe/Lumberjack-Dispatcher-Syslog.git",
-   "license" : "perl",
+   "license" : "Artistic-2.0",
    "meta6" : "0",
    "name" : "Lumberjack::Dispatcher::Syslog",
    "resource" : {},


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license